### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/close-pull-requests.yml
+++ b/.github/workflows/close-pull-requests.yml
@@ -1,4 +1,6 @@
 name: Auto close pull requests
+permissions:
+  pull-requests: write
 on:
   pull_request_target:
     types: [opened, labeled, unlabeled, reopened]


### PR DESCRIPTION
Potential fix for [https://github.com/ekul33/my-portfolio/security/code-scanning/1](https://github.com/ekul33/my-portfolio/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow interacts with pull requests (closing them and adding comments), it requires `pull-requests: write` permissions. Other permissions should be set to `read` or omitted entirely if not needed. The `permissions` block should be added at the workflow level to apply to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
